### PR TITLE
Look for Celeste.exe inside Celeste.app/Contents/MacOS on Mac OS X

### DIFF
--- a/src/init_ahorn.jl
+++ b/src/init_ahorn.jl
@@ -31,7 +31,14 @@ function findCelesteDir()
     steam = findSteamInstallDir()
 
     if steam !== nothing
-        steamfn = joinpath(steam, "steamapps", "common", "Celeste", "Celeste.exe")
+        celesteDir =
+            if Sys.isapple()
+                joinpath("Celeste", "Celeste.app", "Contents", "MacOS")
+            else
+                "Celeste"
+            end
+
+        steamfn = joinpath(steam, "steamapps", "common", celestDir, "Celeste.exe")
 
         if isfile(steamfn)
             return true, steamfn


### PR DESCRIPTION
On Mac OS X (I'm using 10.14.6 Mojave), the `Celeste.exe` file is in `Celeste.app/Contents/MacOS` instead of `Celeste`. I've updated `findCelesteDir` to look there on Apple platforms.

It's somewhat important that we find the executable automatically since the native open dialogue doesn't let you navigate into `.app` bundles anymore. 